### PR TITLE
fix margins not displaying correct background colours

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -101,6 +101,15 @@ struct ast_attributes_t
   uint32_t margin_right;
 };
 
+struct ast_colours_t
+{
+  size_t root_fg;
+  size_t root_bg;
+  size_t node_fg;
+  size_t node_bg;
+  size_t n_colours;
+};
+
 struct ast_t
 {
   enum ast_node_type_e type;

--- a/include/ast_internal.h
+++ b/include/ast_internal.h
@@ -6,6 +6,7 @@
 //forward declarations
 struct ast_t;
 struct ast_attributes_t;
+struct ast_colours_t;
 struct iarray_t;
 
 void
@@ -14,7 +15,8 @@ ast_render_text(
   struct ast_attributes_t* const attributes,
   struct iarray_t* const interactive_items,
   size_t* current_x,
-  size_t* current_y);
+  size_t* current_y,
+  const struct ast_colours_t* const root_colours);
 
 void
 ast_render_space(
@@ -22,7 +24,8 @@ ast_render_space(
   struct ast_attributes_t* const attributes,
   struct iarray_t* const interactive_items,
   size_t* current_x,
-  size_t* current_y);
+  size_t* current_y,
+  const struct ast_colours_t* const root_colours);
 
 void
 ast_render_input(
@@ -30,7 +33,8 @@ ast_render_input(
   struct ast_attributes_t* const attributes,
   struct iarray_t* const interactive_items,
   size_t* current_x,
-  size_t* current_y);
+  size_t* current_y,
+  const struct ast_colours_t* const root_colours);
 
 void
 ast_render_button(
@@ -38,5 +42,6 @@ ast_render_button(
   struct ast_attributes_t* const attributes,
   struct iarray_t* const interactive_items,
   size_t* current_x,
-  size_t* current_y);
+  size_t* current_y,
+  const struct ast_colours_t* const root_colours);
 #endif

--- a/src/ast.c
+++ b/src/ast.c
@@ -367,6 +367,8 @@ ast_draw(
   wbkgd(stdscr, COLOR_PAIR(fg * n_colours + bg));
   attroff(A_BOLD);
 
+  
+
   for (size_t i = 0; i < root->n_children; ++i)
   {
     struct ast_t* child = root->children[i];
@@ -378,23 +380,31 @@ ast_draw(
 
     attrset(COLOR_PAIR(attributes.fg * n_colours + attributes.bg));
 
+    struct ast_colours_t colours = {
+      .root_fg = fg,
+      .root_bg = bg,
+      .node_fg = attributes.fg,
+      .node_bg = attributes.bg,
+      .n_colours = n_colours
+    };
+
     /* render content */
     switch (child->type)
     {
       case TML_NODE_TEXT:
-        ast_render_text(child, &attributes, interactive_items, &current_x, &current_y);
+        ast_render_text(child, &attributes, interactive_items, &current_x, &current_y, &colours);
         break;
 
       case TML_NODE_SPACE:
-        ast_render_space(child, &attributes, interactive_items, &current_x, &current_y);
+        ast_render_space(child, &attributes, interactive_items, &current_x, &current_y, &colours);
         break;
       
       case TML_NODE_INPUT:
-        ast_render_input(child, &attributes, interactive_items, &current_x, &current_y);
+        ast_render_input(child, &attributes, interactive_items, &current_x, &current_y, &colours);
         break;
 
       case TML_NODE_BUTTON:
-        ast_render_button(child, &attributes, interactive_items, &current_x, &current_y);
+        ast_render_button(child, &attributes, interactive_items, &current_x, &current_y, &colours);
         break;
       
       case TML_NODE_NONE:

--- a/src/ast_internal.c
+++ b/src/ast_internal.c
@@ -5,12 +5,20 @@
 static void
 _apply_margin(
   const uint32_t margin,
-  size_t* current_x)
+  size_t* current_x,
+  const struct ast_colours_t* const colours)
 {
+  // do not apply node-specific colours on margin,
+  // use the root node's colours
+  attrset(COLOR_PAIR(colours->root_fg * colours->n_colours + colours->root_bg));
+
   if (margin > 0)
     for (uint32_t i = 0; i < margin; ++i)
       printw(" ");
   (*current_x) += margin;
+
+  // reset back to node-specific colours
+  attrset(COLOR_PAIR(colours->node_fg * colours->n_colours + colours->node_bg));
 }
 
 void
@@ -19,11 +27,12 @@ ast_render_text(
   struct ast_attributes_t* const attributes,
   struct iarray_t* const interactive_items,
   size_t* current_x,
-  size_t* current_y)
+  size_t* current_y,
+  const struct ast_colours_t* const colours)
 {
   (void)interactive_items;
 
-  _apply_margin(attributes->margin_left, current_x);
+  _apply_margin(attributes->margin_left, current_x, colours);
   move(*current_y, *current_x);
   refresh();
 
@@ -41,7 +50,7 @@ ast_render_text(
   else
     *current_x += node->body.length;
 
-  _apply_margin(attributes->margin_right, current_x);
+  _apply_margin(attributes->margin_right, current_x, colours);
   move(*current_y, *current_x);
 }
 
@@ -51,7 +60,8 @@ ast_render_space(
   struct ast_attributes_t* const attributes,
   struct iarray_t* const interactive_items,
   size_t* current_x,
-  size_t* current_y)
+  size_t* current_y,
+  const struct ast_colours_t* const colours)
 {
   (void)node;
   (void)attributes;
@@ -68,9 +78,10 @@ ast_render_input(
   struct ast_attributes_t* const attributes,
   struct iarray_t* const interactive_items,
   size_t* current_x,
-  size_t* current_y)
+  size_t* current_y,
+  const struct ast_colours_t* const colours)
 {
-  _apply_margin(attributes->margin_left, current_x);
+  _apply_margin(attributes->margin_left, current_x, colours);
   move(*current_y, *current_x);
 
   size_t body_len = 0;
@@ -112,7 +123,7 @@ ast_render_input(
     *current_x = 0;
   }
 
-  _apply_margin(attributes->margin_right, current_x);
+  _apply_margin(attributes->margin_right, current_x, colours);
   move(*current_y, *current_x);
 }
 
@@ -122,9 +133,10 @@ ast_render_button(
   struct ast_attributes_t* const attributes,
   struct iarray_t* const interactive_items,
   size_t* current_x,
-  size_t* current_y)
+  size_t* current_y,
+  const struct ast_colours_t* const colours)
 {
-  _apply_margin(attributes->margin_left, current_x);
+  _apply_margin(attributes->margin_left, current_x, colours);
   move(*current_y, *current_x);
 
   size_t body_len = 0;
@@ -151,6 +163,6 @@ ast_render_button(
     *current_x = 0;
   }
 
-  _apply_margin(attributes->margin_right, current_x);
+  _apply_margin(attributes->margin_right, current_x, colours);
   move(*current_y, *current_x);
 }


### PR DESCRIPTION
margins were using the node's background instead of the root background colour